### PR TITLE
ci: migrate CodeQL runner to self-hosted ARC (stage)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
Migrate the CodeQL `analyze` job from `ubuntu-latest` to `${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}` (CodeQL pinned to _4 per policy). k8s-build.yml already on the ARC var. No arm/macos/windows runners affected.